### PR TITLE
Howtos, Asciicasting, and programmatic header

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,21 @@ special-categories:
   - "exercise"
   - "how-to"
 
+# These can contain uppercase: they'll be lowercased in the URL
+page-order:
+  - syllabus
+  - schedule
+  - exercises
+  - how-to
+  - people
+  - feedback
+  - music
+
+# Same note RE case above
+python-extra-pages:
+  - console
+  
+  
 baseurl: /spring2014
 url: /spring2014
 

--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,10 @@ markdown: redcarpet
 redcarpet:
   extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data"]
 
+special-categories: 
+  - "exercise"
+  - "how-to"
+
 baseurl: /spring2014
 url: /spring2014
 

--- a/_drafts/2014-01-18-jekyllnitrouspreview.md
+++ b/_drafts/2014-01-18-jekyllnitrouspreview.md
@@ -1,0 +1,45 @@
+---
+layout: post
+author: elliott
+title: Asciicasting (for TAs and Profs)
+categories: how-to
+published: false
+---
+
+
+
+## Proof of concept Asciicast post
+
+Here is a screencast of how to start up and preview your changes to our class site before they're pushed to Github Pages.  This assumes you've already `git clone`d the repo.
+
+<script type="text/javascript" src="http://asciinema.org/a/7262.js" id="asciicast-7262" async></script>
+
+You can see there were a few typos and errors (e.g. Jekyll was already running so it threw an error) but you can also see the power.  Note that the video is the same shape as the terminal window I was using.  You may want to resize before recording.
+
+## How to set up Asciicasting (for TAs and Profs)
+
+On nitrous it's a pain to install asciinema, but totally doable.
+
+Follow the instruction in the bottom (2 pt) answer [here](http://askubuntu.com/questions/339/how-can-i-install-a-package-without-root-access).  The `.deb` is here: https://launchpad.net/~zanchey/+archive/asciinema/+files/asciinema_0.9.7-1_all.deb  Instead of `tmp` I installed it in `workspace`.  You'll have a binary you can run then by typing its full path but you'll want to `alias` that binary to something simple.  I added
+
+```
+alias asciinema="~/workspace/usr/bin/asciinema"
+```
+
+to my `.bashrc`.  Then you can `source ~/.bashrc` or open a new terminal window and this should
+
+On any other system where you have root access setup is [easy](http://asciinema.org/docs)
+
+## How to post ASCIIcasts
+
+You'll need to register via `asciinema auth`.  From there you can embed a cast via the embed code on the site itself or this way:
+
+```
+{% raw %}
+{% include asciinema number="7263" size="medium" speed="3"%}
+{% endraw %}
+```
+
+You can parse the number out of the URL pretty easily, so if you use this include code you don't even have to leave your terminal to embed the video :)
+
+The `size` and `speed` parameters are optional, and our custom defaults are shown above.  If you don't use the `include` the embed code defaults to a speed of `1` which is pretty slow.

--- a/_drafts/2014-01-18-jekyllnitrouspreview.md
+++ b/_drafts/2014-01-18-jekyllnitrouspreview.md
@@ -18,17 +18,11 @@ You can see there were a few typos and errors (e.g. Jekyll was already running s
 
 ## How to set up Asciicasting (for TAs and Profs)
 
-On nitrous it's a pain to install asciinema, but totally doable.
+Asciicasting is really easy to set up.
 
-Follow the instruction in the bottom (2 pt) answer [here](http://askubuntu.com/questions/339/how-can-i-install-a-package-without-root-access).  The `.deb` is here: https://launchpad.net/~zanchey/+archive/asciinema/+files/asciinema_0.9.7-1_all.deb  Instead of `tmp` I installed it in `workspace`.  You'll have a binary you can run then by typing its full path but you'll want to `alias` that binary to something simple.  I added
-
+```bash
+$ pip install --user asciinema
 ```
-alias asciinema="~/workspace/usr/bin/asciinema"
-```
-
-to my `.bashrc`.  Then you can `source ~/.bashrc` or open a new terminal window and this should
-
-On any other system where you have root access setup is [easy](http://asciinema.org/docs)
 
 ## How to post ASCIIcasts
 

--- a/_includes/asciinema
+++ b/_includes/asciinema
@@ -1,0 +1,20 @@
+
+{% capture size %}{{ include.size }}{% endcapture %}
+{% if size %}
+{% else %}
+{% assign size="medium" %}
+{% endif %}
+
+{% capture number %}{{ include.number }}{% endcapture %}
+{% if number %}
+{% else %}
+{% assign number="7263" %}
+{% endif %}
+
+{% capture speed %}{{ include.speed }}{% endcapture %}
+{% if speed %}
+{% else %}
+{% assign speed="3" %}
+{% endif %}
+
+<script type="text/javascript" src="http://asciinema.org/a/{{ number }}.js" id="asciicast-{{ number }}" async data-speed="{{ speed }}" data-size="{{ size }}"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,22 +26,21 @@
     </head>
     <body>
         <!-- Ribbon -->
-        <a href="https://github.com/silshack/professorjekyll"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
+      <a href="https://github.com/silshack{{ site.baseurl }}"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
         
         <div class="container">
           <div class="site">
             <div class="header">
               <h1 class="title"><a href="{{ site.baseurl }}/">{{ site.name }}</a></h1>
               <p>
-              <a class="extra" href="{{ site.baseurl }}/syllabus.html">syllabus</a>
-              <a class="extra" href="{{ site.baseurl }}/schedule.html#today">schedule</a>
-              <a class="extra" href="{{ site.baseurl }}/exercises.html">exercises</a>
-              <a class="extra" href="{{ site.baseurl }}/people.html">people</a>
-              <a class="extra" href="{{ site.baseurl }}/feedback.html">feedback</a>
-              <a class="extra" href="{{ site.baseurl }}/music.html">music</a>
-              {% if site.python == true %}
-              <a class="extra" href="{{ site.baseurl }}/console.html">console</a>
-              {% endif %}
+                {% for pagename in site.page-order %}
+                <a class="extra" href="{{ site.baseurl }}/{{ pagename | lower }}.html">{{ pagename }}</a>
+                {% endfor %}
+                {% if site.python == true %}
+                {% for pagename in site.python-extra-pages %}
+                <a class="extra" href="{{ site.baseurl }}/{{ pagename }}.html">{{ pagename }}</a>
+                {% endfor %}                
+                {% endif %}
               </p>
             </div>
 

--- a/_posts/how-tos/2014-02-01-git-howto.md
+++ b/_posts/how-tos/2014-02-01-git-howto.md
@@ -2,7 +2,7 @@
 layout: post
 author: elliott
 categories: how-to
-published: false
+published: true
 title: Setting up Git
 ---
 

--- a/how-to.markdown
+++ b/how-to.markdown
@@ -1,0 +1,17 @@
+---
+layout: default
+title: "How-tos"
+---
+
+## {{ site.course.number }} How-tos
+
+General references for how to do useful things for this class.
+
+<ul class="posts">
+
+{% assign how-tos = site.categories.how-to %}
+{% for post in how-tos %}
+    <li><a href=" {{ site.baseurl }}{{ post.url }} "> {{ post.title }} </a></li>
+{% endfor %}
+
+</ul>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,13 @@ title: "Coursehacker's Class Blog"
 <div id="home">
   <ul class="posts">
     {% for post in site.posts %}
-      {% if post.categories contains "exercise" %}
-      {% else %}
+      {% assign print = "true" %}
+      {% for category in site.special-categories %}
+          {% if post.categories contains category %}
+            {% assign print = false %}
+          {% endif %}
+      {% endfor %}
+      {% if print %}  
         {% for authors in post.author %}
     	  {% if {{site.authors[authors].prof}} == true %}
             <strong>


### PR DESCRIPTION
Adds Howtos section in the header, easy Asciicasting, Asciicasting How-to for TAs & instructors (run `jekyll serve --drafts` and go to how-tos.html to see this), and a programmatically generated header keyed off a list in `_config.yml`.
