### PR TITLE
disabled cursor blink in read-only code blocks

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -115,7 +115,8 @@ $(document).ready(function () {
             textWrapping: false,
             indentUnit: 4,
             height: "160px",
-            fontSize: "9pt"
+            fontSize: "9pt",
+            nocursor: true
         });
 
     });


### PR DESCRIPTION
``` code blocks no longer get cursor blink.
