### PR TITLE
Rejiggered the code-mirror code-blocks a bit

### DIFF
--- a/_includes/endpython
+++ b/_includes/endpython
@@ -1,6 +1,6 @@
-```  
-</textarea>
-<br /><button id='btn{{include.id}}'>Run</button>
+</textarea></pre><div class="codeblock">
+<button id='btn{{include.id}}'>Run</button>
 <p>Output: (<a href="#" id="clearoutput{{include.id}}">clear</a>)</p>
-<pre id="edoutput{{include.id}}">Press Run to see the output of the code above</pre>
+<pre class="output" id="edoutput{{include.id}}">Press Run to see the output of the code above</pre>
 <canvas id="mycanvas{{include.id}}" height="400" width="400" style="border-style: solid; display: none"></canvas>
+</div>

--- a/_includes/python
+++ b/_includes/python
@@ -1,6 +1,5 @@
-<script type="text/javascript">
+<p><script type="text/javascript">
 idmods.push('{{include.id}}')
 </script>
-<textarea id='code{{include.id}}' rows="12" cols="80">
 
-```
+<pre><textarea id='code{{include.id}}' rows="12" cols="80">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,16 +26,9 @@
     <script src="{{ site.baseurl}}/js/date-cs.js" type="text/javascript"></script>
     
     <!--Code Mirror and Console scripts-->
-    <script src="http://www.skulpt.org/static/skulpt.min.js" type="text/javascript"></script>
-    <script src="http://www.skulpt.org/static/skulpt-stdlib.js" type="text/javascript"></script>
     <script type="text/javascript">
         var idmods = new Array();
     </script>
-    <script src="{{ site.baseurl }}/js/codemirrorepl.js" type="text/javascript"></script>
-    <script src="{{ site.baseurl }}/js/python.js" type="text/javascript"></script>
-    <script src="{{ site.baseurl }}/js/codemirror/js/bash.js" type="text/javascript"></script>
-    <script src="{{ site.baseurl }}/js/editor.js" type="text/javascript"></script>
-
 
 </head>
 
@@ -81,6 +74,14 @@
         </div>
     </div>
     <!-- /container -->
+    <!-- Script imports at bottom to decrease page-load-time-->
+    <script src="http://www.skulpt.org/static/skulpt.min.js" type="text/javascript"></script>
+    <script src="http://www.skulpt.org/static/skulpt-stdlib.js" type="text/javascript"></script>
+    <script src="{{ site.baseurl }}/js/codemirrorepl.js" type="text/javascript"></script>
+    <script src="{{ site.baseurl }}/js/python.js" type="text/javascript"></script>
+    <script src="{{ site.baseurl }}/js/codemirror/js/bash.js" type="text/javascript"></script>
+    <script src="{{ site.baseurl }}/js/editor.js" type="text/javascript"></script>
+
 
 </body>
 <script src="{{ site.baseurl}}/js/date-cs.js" type="text/javascript"></script>

--- a/_posts/how-tos/2014-01-21-consoles.md
+++ b/_posts/how-tos/2014-01-21-consoles.md
@@ -8,39 +8,31 @@ categories: how-to
 You can include runnable code in your post by adding a Python console:
 
 {% include python %}
-
 for i in ["I", "love", "Python"]:
   print i
-  
 {% include endpython %}
 
 You'll need some include statements to do this.  Include statements pull in code that starts and finishes the code block:
 
 ```
 {% raw %}{% include python %}
-
 for i in ["I", "love", "Python"]:
   print i
-  
 {% include endpython %}{% endraw %}
 ```
 
 If you want more than one console in your post, add `id='uniqueID'` to the includes statement. Each console needs a unique id value:
 
 ```
-{% raw %}{% include python id='1'%}
-
+{% raw %}{% include python id='1'%
 for i in ["I", "love", "Python", "too"]:
   print i
-  
 {% include endpython id='1' %}{% endraw %}
 ```
 
 {% include python id='1'%}
-
 for i in ["I", "love", "Python", "too"]:
   print i
-  
 {% include endpython id='1' %}
 
 A HUGE thanks to SILShacker and TA Grant McLendon for getting this working and looking pretty.

--- a/css/main.css
+++ b/css/main.css
@@ -174,7 +174,7 @@ ul.posts span {
 }
 
 
-.post pre {
+pre {
   padding: 0 .4em;
 }
 
@@ -208,7 +208,7 @@ ul.posts span {
   background-color: #333;
 }
 
-#edoutput {
+.output {
     background: #ccc;
     color: #black;
     height: 100px;
@@ -225,4 +225,17 @@ line-height: 1.2em;
 
 code, pre {
   color: #444;
+}
+
+.codeblock{
+  padding: 0 .4em;
+  margin-left: 14px;
+}
+.codeblock pre.output{
+  margin-left: 0;
+  padding: 0;
+}
+
+.codeblock p{
+  margin-bottom: 0;
 }

--- a/css/xq-light.css
+++ b/css/xq-light.css
@@ -21,12 +21,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 .cm-s-xq-light{
-    font-size:13px
+    font-size:13px;
+    line-height: 14px;
 }
 .cm-s-xq-light.CodeMirror {
   border: 1px solid black; 
   font-size:13px;
-  line-height: 1;
+  line-height: 14px;
   position: relative;
   overflow: hidden;
   background: white;

--- a/js/editor.js
+++ b/js/editor.js
@@ -7,7 +7,7 @@ $(document).ready(function () {
             //console.log('stripping');
         }
         var strippedtext = strip($('#code' + idmod).text());
-        $('#code' + idmod).text(strippedtext.substr(1));
+        $('#code' + idmod).text(strippedtext);
         var editor = CodeMirror.fromTextArea(document.getElementById('code' + idmod), {
             parserfile: ["parsepython.js"],
             autofocus: true,
@@ -103,7 +103,7 @@ $(document).ready(function () {
         if (lang === "text") {
             lang = "python"
         };
-        console.log($unescaped.substr(0, $unescaped.length - 1));
+        //console.log($unescaped.substr(0, $unescaped.length - 1));
         $this.empty();
 
         CodeMirror(this, {


### PR DESCRIPTION
Tweaked the styling, the includes, and the scripting to work better and be slightly less hacky. 

Python includes now use <pre> for code blocks instead of ```. This means the html that Jekyll spits out is much cleaner and easier for codemirror to render. The code in the codeblocks is passed to codemirror is exactly as the user enters it, rather than stylized and then de-stylized.

Also code blocks are more visually consistent.
